### PR TITLE
docのアップデート　　

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,26 @@
 ## アーキテクチャ概要
 
 ```text
-[Next.js (TS)]
-   │  JWT
+[Next.js 16 (TS/React 19)]
+   │ JWT付き fetch
    ▼
-[Supabase Auth + Edge Functions]
-   │  HTTP (内部API)
+[Supabase Auth]
+   │ access_token
    ▼
-[Python RAG Backend (Onion)]
-   │  SQL (pgvector)
+[Supabase Edge Functions]
+   ├─ rag-answer (FAQ回答転送)
+   └─ rag-ingest  (必要に応じてインジェスト転送)
+        │
+        ▼
+[FastAPI RAG Backend]
+   ├─ /answer /search /ingest /documents/upload
    ▼
 [Supabase Postgres + pgvector]
 ```
+
+- 質問/回答は Edge Function で JWT 検証後に FastAPI へ転送。
+- ドキュメントアップロードは Next.js → FastAPI `/documents/upload` へ直接 POST（PDF受信→一時保存→Ingest）。
+- サインアップで `company_name` メタデータを送信し、DBトリガーで `tenants` と `profiles` を原子的に作成。
 
 ## プロジェクト構成
 
@@ -31,11 +40,12 @@
 - `src/features/faq` - FAQ機能
 - `src/features/documents` - ドキュメント管理
 
-### `backend-python/` (Onion Architecture)
-- `domain/` - Document, Chunk, Embedding, IngestJob などのドメインモデル
-- `application/` - UseCase（IngestDocument, ReindexDocument など）
-- `infrastructure/` - pgvectorリポジトリ, LLMクライアント(Claude/Gemini), PDF抽出
-- `interface/` - FastAPI などHTTPインターフェース
+### `backend/` (Onion + Clean/Hexagonal 要素)
+- 依存方向: `domain` ← `application` ← `infrastructure` ← `interface`
+- `domain/` … entities/repositories/services（純粋なモデルと契約）
+- `application/use_cases/` … ingest/search/generate_embeddings/generate_answer などユースケース層
+- `infrastructure/` … Supabase/pgvectorリポジトリ実装、LLMクライアント、PDF抽出
+- `interface/api/` … FastAPIエンドポイント（/health, /ingest, /search, /answer, /documents/upload）
 
 ### `supabase/`
 - スキーマ、RLSポリシー
@@ -44,16 +54,12 @@
 ## 主な機能
 
 ### ドキュメント処理
-PDF/Wordをアップロードすると自動で以下の処理を実行：
-1. テキスト抽出
-2. チャンク分割
-3. 埋め込み生成
-4. pgvector保存
+- Next.js `/documents` から PDF をアップロード → FastAPI `/documents/upload` で受信
+- PDF抽出 → チャンク分割 → 埋め込み生成 → pgvectorへ保存
 
 ### FAQ回答生成
-ユーザーの質問に対して以下を実行：
-1. Top-Kベクトル検索
-2. 根拠付き回答（引用＋出典メタ）を生成
+- Edge Function rag-answer で JWT を検証し、FastAPI `/answer` へ転送
+- Top-K ベクトル検索 → 回答生成（引用・スコア付き）を返却
 
 ### セキュリティ
 - すべてのAPIを Supabase Auth の認証下に配置

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,9 +26,11 @@
 
 ---
 
-## バックエンド (FastAPI / Onion)
+## バックエンド (FastAPI / Onion + Clean/Hexagonal要素)
 
-依存方向: `domain` ← `application` ← `infrastructure` ← `interface`
+- 基本は Onion の依存方向: `domain` ← `application` ← `infrastructure` ← `interface`
+- `application/use_cases` を中心にユースケース層を分離しており、Clean/Hexagonal のポート/アダプタ的要素を取り入れている
+- `infrastructure` はリポジトリ実装や外部I/Oのアダプタとして機能し、`domain`/`application` への依存を一方向に保持する
 
 ```
 backend/

--- a/frontend/src/features/auth/components/SignupForm.tsx
+++ b/frontend/src/features/auth/components/SignupForm.tsx
@@ -26,6 +26,9 @@ export default function SignupForm() {
         companyName,
         fullName: fullName || undefined,
       });
+      console.info(
+        "サインアップ完了: 確認メールをチェックして認証してください。",
+      );
     } catch (err) {
       // useTenantRegister がエラー状態を保持するため rethrow を握りつぶしてログだけ
       console.error("Signup failed:", err);


### PR DESCRIPTION
README.mdのドキュメントをアップデート

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes architecture docs (README and ARCHITECTURE) and adds a signup success console message in SignupForm.
> 
> - **Documentation**:
>   - **README**: Update system diagram (Next.js 16/React 19), clarify Supabase Auth vs Edge Functions, list FastAPI endpoints, and document flows (upload, answer, signup metadata `company_name`).
>   - **`docs/ARCHITECTURE.md`**: Expand backend layering (Onion + Clean/Hexagonal), detailed directories for `backend/` and frontend, data flows (ingest/search/signup), and stack details.
> - **Frontend**:
>   - `frontend/src/features/auth/components/SignupForm.tsx`: Log signup success via `console.info` after `signUpTenant`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63873b5d0525aef153732c2792685a9903984ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->