### PR TITLE
Bug: 参照文献が表示されないバグを修正

### DIFF
--- a/backend/src/application/use_cases/generate_answer.py
+++ b/backend/src/application/use_cases/generate_answer.py
@@ -130,7 +130,8 @@ class GenerateAnswerUseCase:
                 sources.append({
                     "document_id": doc_id,
                     "section": metadata.get('section'),
-                    "score": chunk.get('score')
+                    "score": chunk.get('score'),
+                    "content": chunk.get('content')
                 })
         
         return sources

--- a/frontend/src/features/faq/components/AnswerDisplay.tsx
+++ b/frontend/src/features/faq/components/AnswerDisplay.tsx
@@ -46,7 +46,7 @@ export function AnswerDisplay({ answer }: AnswerDisplayProps) {
                 </span>
               </div>
               <p className="whitespace-pre-wrap">
-                {source.section || "引用テキスト情報がありません"}
+                {source.content || "引用テキスト情報がありません"}
               </p>
             </div>
           ))}

--- a/frontend/src/features/faq/services/faqService.ts
+++ b/frontend/src/features/faq/services/faqService.ts
@@ -14,6 +14,7 @@ export interface AnswerResponse {
     document_id: string;
     section: string | null;
     score: number;
+    content: string;
   }>;
   elapsed_time: number;
 }


### PR DESCRIPTION
## 概要
RAG回答にあたり、参照した資料が表示されないバグを発見し、修正

## 修正内容
バックエンド：
`application/use_cases/generagtaanswer.py`の`_extract_sources()`関数にて`content`を追加
```py
sources.append({
                    "document_id": doc_id,
                    "section": metadata.get('section'),
                    "score": chunk.get('score'),
                    "content": chunk.get('content')
                })
```

フロントエンド：
AnswerResponse 型に content: string を追加
```ts
    sources: Array<{
      document_id: string;
      section: string | null;
      score: number;
      content: string;
    }>;
```

AnswerDisplay で引用表示に使うフィールドを section から content に変更
```ts
    <p className="whitespace-pre-wrap">
      {source.content || "引用テキスト情報がありません"}
    </p>
```


## チェック項目
 - [ ] RAG回答にて参照が返ってくるか